### PR TITLE
Actually install npm

### DIFF
--- a/install-smartgarage.sh
+++ b/install-smartgarage.sh
@@ -246,9 +246,9 @@ function install_node_repo() {
 function install_nodejs_and_npm() {
 	infopart 4 "Installing Node.js and npm..."
 	if execute_step ; then
-		echo "$ apt-get install -y nodejs"
+		echo "$ apt-get install -y nodejs npm"
 		echo ""
-		apt-get install -y nodejs
+		apt-get install -y nodejs npm
 	fi
 }
 


### PR DESCRIPTION
In my runthrough, the script does not install npm and fails at the Homebridge step. This edit installs npm.

Note: the script/npm will warn user about running with a newer version of npm. Doesn't appear to affect anything.